### PR TITLE
Update response to always use prompt name as key

### DIFF
--- a/src/riddlerps.psm1
+++ b/src/riddlerps.psm1
@@ -152,15 +152,13 @@ function Get-PromptResult{
                 $optStr = (ConvertTo-OptionsString -options $options)
                 $promptResult = Prompt-OptionsString -optionsString $optStr -optionsType $optionsType
 
-                foreach($key in $promptResult.Keys){
-                    $results[$key]=$true
-                }
+
                 if($optionsType -eq 'PickOne'){
                     $result[$prompt.Name]=($promptResult.Keys | Select-Object -First 1)
                 }
                 elseif($optionsType -eq 'PickMany'){
                     foreach($key in $promptResult.Keys){
-                        $result[$key]=$key
+                        $result[$prompt.Name]=$promptResult.Keys
                     }
                 }
                 $getValFromUser = $false


### PR DESCRIPTION
The example in the [README](https://github.com/stuartleeks/riddlerps/blob/stuartleeks/powershellgallery/README.md) has three prompts: name, bread and filling. The filling is a PickMany.

In the original implementation, the output is:

``` powershell
Name                           Value
----                           -----
tuna                           tuna
green-stuff                    green-stuff
mayo                           mayo
name                           Stuart
bread                          brown
```

This PR proposes changing it to:

``` powershell
Name                           Value
----                           -----
fillings                       {tuna, mayo, green-stuff}
name                           Stuart
bread                          brown
```

I think that this is easier to work with as the consumer doesn't have to test all the values. It also allows for multiple prompts in the same invoke that use the same value.

NOTE: I'm happy to rebase this on top of the PowerShell Gallery change :-)
